### PR TITLE
GTKWave updates

### DIFF
--- a/scripts/addWavesRecursive.tcl
+++ b/scripts/addWavesRecursive.tcl
@@ -161,6 +161,10 @@ set dmt      [ gtkwave::getDumpType     ]
 # puts "\[savefile\]"
 # puts "\[timestart\] 0"
 
+# Keep the SST pane (left pane) collapsed as all signals are already
+# included
+puts "\[sst_expanded\] 0"
+
 # Get a list of all the signals in the design that are not "generated"
 # or "temporary".
 puts stderr "\[INFO\] Reading all signals in design"

--- a/scripts/addWavesRecursive.tcl
+++ b/scripts/addWavesRecursive.tcl
@@ -167,7 +167,7 @@ puts stderr "\[INFO\] Reading all signals in design"
 set signals [list]
 for {set i 0} {$i < $nfacs } {incr i} {
     set facname [ gtkwave::getFacName $i ]
-    if {![regexp {^.*\.(GEN|T)_.*} $facname]} {
+    if {![regexp {^.*\._(GEN|T).*} $facname]} {
         lappend signals "$facname"
     }
 }

--- a/scripts/gtkwave-helper
+++ b/scripts/gtkwave-helper
@@ -7,7 +7,7 @@
 # signals grouped by module.
 
 usage () {
-    echo "Usage: $0 [vcd-file]"
+    echo "Usage: $0 [vcd-file]" >&2
 }
 
 base_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"/..
@@ -22,7 +22,7 @@ if [ ! -f $base_dir/opt/bin/gtkwave ]; then
     make -C $base_dir gtkwave;
 fi;
 
-echo "[INFO] Preprocessing $1 to generate $1.gtkw"
+echo "[INFO] Preprocessing $1 to generate $1.gtkw" >&2
 time $ENV gtkwave -g -S $base_dir/scripts/addWavesRecursive.tcl $1 > $1.gtkw
-echo "[INFO] Launching graphical GTKWave..."
+echo "[INFO] Launching graphical GTKWave..." >&2
 $ENV gtkwave -g $1 $1.gtkw


### PR DESCRIPTION
This includes small updates to the GTKWave scripts:

- `gtkwave-helper` now prints to STDERR instead of STDOUT
- The regex used to filter Chisel3 temporaries is fixed
- The SST (left) pane in GTKWave will now start collapsed